### PR TITLE
PoC: Data stream lifecycle default enabled with lifecycle flag

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
@@ -162,7 +162,8 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
             TimeValue dataRetention = randomBoolean() ? null : TimeValue.timeValueMillis(randomMillisUpToYear9999());
             PutDataStreamLifecycleAction.Request putDataLifecycleRequest = new PutDataStreamLifecycleAction.Request(
                 new String[] { "*" },
-                dataRetention
+                dataRetention,
+                true
             );
             assertThat(
                 client().execute(PutDataStreamLifecycleAction.INSTANCE, putDataLifecycleRequest).get().isAcknowledged(),

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -705,7 +705,8 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
     static void updateLifecycle(String dataStreamName, TimeValue dataRetention) {
         PutDataStreamLifecycleAction.Request putDataLifecycleRequest = new PutDataStreamLifecycleAction.Request(
             new String[] { dataStreamName },
-            dataRetention
+            dataRetention,
+            true
         );
         AcknowledgedResponse putDataLifecycleResponse = client().execute(PutDataStreamLifecycleAction.INSTANCE, putDataLifecycleRequest)
             .actionGet();

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/PutDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/PutDataStreamLifecycleAction.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.DATA_RETENTION_FIELD;
+import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.ENABLED_FIELD;
 
 /**
  * Sets the data stream lifecycle that was provided in the request to the requested data streams.
@@ -47,7 +48,7 @@ public class PutDataStreamLifecycleAction extends ActionType<AcknowledgedRespons
 
         public static final ConstructingObjectParser<Request, Void> PARSER = new ConstructingObjectParser<>(
             "put_data_stream_lifecycle_request",
-            args -> new Request(null, ((TimeValue) args[0]))
+            args -> new Request(null, ((TimeValue) args[0]), (Boolean) args[1])
         );
 
         static {
@@ -57,6 +58,7 @@ public class PutDataStreamLifecycleAction extends ActionType<AcknowledgedRespons
                 DATA_RETENTION_FIELD,
                 ObjectParser.ValueType.STRING_OR_NULL
             );
+            PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), ENABLED_FIELD);
         }
 
         public static Request parseRequest(XContentParser parser) {
@@ -82,9 +84,10 @@ public class PutDataStreamLifecycleAction extends ActionType<AcknowledgedRespons
             out.writeWriteable(lifecycle);
         }
 
-        public Request(String[] names, @Nullable TimeValue dataRetention) {
+        public Request(String[] names, @Nullable TimeValue dataRetention, @Nullable Boolean enabled) {
             this.names = names;
-            this.lifecycle = DataStreamLifecycle.newBuilder().dataRetention(dataRetention).build();
+            // We consider that when a user explicitly adds a lifecycle they want it to be enabled.
+            this.lifecycle = DataStreamLifecycle.newBuilder().dataRetention(dataRetention).enabled(enabled == null || enabled).build();
         }
 
         public String[] getNames() {

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -160,8 +160,10 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     // Introduced for stateless plugin
     public static final TransportVersion V_8_500_036 = registerTransportVersion(8_500_036, "3343c64f-d7ac-4f02-9262-3e1acfc56f89");
 
+    public static final TransportVersion V_8_500_037 = registerTransportVersion(8_500_037, "80c088c6-358d-43b2-8d9c-1ea3c6c2b9fd");
+
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_036);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_037);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -669,7 +669,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     }
 
     /**
-     * This is the raw defintion of an index being managed by the data stream lifecycle. An index is managed by the data stream lifecycle
+     * This is the raw definition of an index being managed by the data stream lifecycle. An index is managed by the data stream lifecycle
      * if it's part of a data stream that has a data stream lifecycle configured and depending on the value of
      * {@link org.elasticsearch.index.IndexSettings#PREFER_ILM_SETTING} having an ILM policy configured will play into the decision.
      * This method also skips any validation to make sure the index is part of this data stream, hence the private
@@ -677,11 +677,11 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
      */
     private boolean isIndexManagedByDataStreamLifecycle(IndexMetadata indexMetadata) {
         boolean preferIlm = PREFER_ILM_SETTING.get(indexMetadata.getSettings());
-        if (indexMetadata.getLifecyclePolicyName() != null && lifecycle != null) {
+        if (indexMetadata.getLifecyclePolicyName() != null && (lifecycle != null && lifecycle.isUserEnabled())) {
             // when both ILM and data stream lifecycle are configured, choose depending on the configured preference for this backing index
             return preferIlm == false;
         }
-        return lifecycle != null;
+        return lifecycle != null && lifecycle.isOptOut() == false;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -677,11 +677,11 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
      */
     private boolean isIndexManagedByDataStreamLifecycle(IndexMetadata indexMetadata) {
         boolean preferIlm = PREFER_ILM_SETTING.get(indexMetadata.getSettings());
-        if (indexMetadata.getLifecyclePolicyName() != null && (lifecycle != null && lifecycle.isUserEnabled())) {
+        if (indexMetadata.getLifecyclePolicyName() != null && (lifecycle != null && lifecycle.enabled())) {
             // when both ILM and data stream lifecycle are configured, choose depending on the configured preference for this backing index
             return preferIlm == false;
         }
-        return lifecycle != null && lifecycle.isOptOut() == false;
+        return lifecycle != null && lifecycle.enabled();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -155,8 +155,24 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
      *  - false, if they explicitly disabled it
      *  - null, otherwise
      */
-    Boolean enabled() {
+    Boolean enabledValue() {
         return enabled;
+    }
+
+    /**
+     * Returns true if the user specifically asked for this data stream to be managed by
+     * the data stream lifecycle.
+     */
+    boolean isUserEnabled() {
+        return enabled != null && enabled;
+    }
+
+    /**
+     * Returns true if the user specifically asked for this data stream to not be managed by
+     * the data stream lifecycle.
+     */
+    boolean isOptOut() {
+        return enabled != null && enabled == false;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -267,9 +267,6 @@ public class MetadataCreateDataStreamService {
         DataStreamLifecycle lifecycle = isSystem
             ? MetadataIndexTemplateService.resolveLifecycle(template, systemDataStreamDescriptor.getComponentTemplates())
             : MetadataIndexTemplateService.resolveLifecycle(template, metadata.componentTemplates());
-        if (lifecycle == null && template.getDataStreamTemplate() != null) {
-            lifecycle = new DataStreamLifecycle();
-        }
         DataStream newDataStream = new DataStream(
             dataStreamName,
             dsBackingIndices,
@@ -280,7 +277,7 @@ public class MetadataCreateDataStreamService {
             isSystem,
             template.getDataStreamTemplate().isAllowCustomRouting(),
             indexMode,
-            lifecycle
+            lifecycle == null ? new DataStreamLifecycle() : lifecycle
         );
         Metadata.Builder builder = Metadata.builder(currentState.metadata()).put(newDataStream);
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -264,9 +264,12 @@ public class MetadataCreateDataStreamService {
         dsBackingIndices.add(writeIndex.getIndex());
         boolean hidden = isSystem || template.getDataStreamTemplate().isHidden();
         final IndexMode indexMode = metadata.isTimeSeriesTemplate(template) ? IndexMode.TIME_SERIES : null;
-        final DataStreamLifecycle lifecycle = isSystem
+        DataStreamLifecycle lifecycle = isSystem
             ? MetadataIndexTemplateService.resolveLifecycle(template, systemDataStreamDescriptor.getComponentTemplates())
             : MetadataIndexTemplateService.resolveLifecycle(template, metadata.componentTemplates());
+        if (lifecycle == null && template.getDataStreamTemplate() != null) {
+            lifecycle = new DataStreamLifecycle();
+        }
         DataStream newDataStream = new DataStream(
             dataStreamName,
             dsBackingIndices,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -739,7 +739,7 @@ public class MetadataIndexTemplateService {
         ComposableIndexTemplate template
     ) {
         boolean hasLifecycle = (template.template() != null && template.template().lifecycle() != null)
-            || resolveLifecycle(template, metadata.componentTemplates()) != null;
+            || resolveLifecycle(template, metadata.componentTemplates()).enabledValue() != null;
         if (hasLifecycle && template.getDataStreamTemplate() == null) {
             throw new IllegalArgumentException(
                 "index template ["
@@ -1511,10 +1511,8 @@ public class MetadataIndexTemplateService {
     public static DataStreamLifecycle composeDataLifecycles(List<DataStreamLifecycle> lifecycles) {
         DataStreamLifecycle.Builder builder = null;
         for (DataStreamLifecycle current : lifecycles) {
-            if (current == Template.NO_LIFECYCLE) {
-                builder = null;
-            } else if (builder == null) {
-                builder = DataStreamLifecycle.newBuilder(current);
+            if (builder == null) {
+                builder = DataStreamLifecycle.newBuilder(current).enabled(true);
             } else {
                 if (current.getDataRetention() != null) {
                     builder.dataRetention(current.getDataRetention());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -739,7 +739,7 @@ public class MetadataIndexTemplateService {
         ComposableIndexTemplate template
     ) {
         boolean hasLifecycle = (template.template() != null && template.template().lifecycle() != null)
-            || resolveLifecycle(template, metadata.componentTemplates()).enabledValue() != null;
+            || resolveLifecycle(template, metadata.componentTemplates()) != null;
         if (hasLifecycle && template.getDataStreamTemplate() == null) {
             throw new IllegalArgumentException(
                 "index template ["

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataAndIndexLifecycleMixingTests.java
@@ -214,7 +214,7 @@ public class DataAndIndexLifecycleMixingTests extends ESIntegTestCase {
         // let's migrate this data stream to use the data stream lifecycle starting with the next generation
         client().execute(
             PutDataStreamLifecycleAction.INSTANCE,
-            new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, TimeValue.timeValueDays(90))
+            new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, TimeValue.timeValueDays(90), true)
         );
 
         // at this point we should be able to rollover the data stream by indexing only one document (as the data stream lifecycle is
@@ -380,7 +380,7 @@ public class DataAndIndexLifecycleMixingTests extends ESIntegTestCase {
         // let's migrate this data stream to use the data stream lifecycle starting with the next generation
         client().execute(
             PutDataStreamLifecycleAction.INSTANCE,
-            new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, TimeValue.timeValueDays(90))
+            new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, TimeValue.timeValueDays(90), true)
         );
 
         putComposableIndexTemplate(
@@ -558,7 +558,7 @@ public class DataAndIndexLifecycleMixingTests extends ESIntegTestCase {
         // managed by ILM to data stream lifecycle)
         client().execute(
             PutDataStreamLifecycleAction.INSTANCE,
-            new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, TimeValue.timeValueDays(90))
+            new PutDataStreamLifecycleAction.Request(new String[] { dataStreamName }, TimeValue.timeValueDays(90), true)
         );
 
         // at this point, the write index of the data stream is managed by data stream lifecycle and not by ILM anymore so we can just index


### PR DESCRIPTION
In this PoC we play around with the option to introduce an `enabled` flag in the `lifecycle` object.

There is more work to be done, namely:
- remove the nullified data stream lifecycle, the flag should cover this too
- do a sanity check by adjusting some of the tests and running some scenarios.