### PR TITLE
[PoC] Introduce a setting-like structure for data stream options configuration

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -66,9 +66,8 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAction;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
-import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
-import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadataStats;
 import org.elasticsearch.cluster.metadata.IndexWriteLoad;
@@ -2449,7 +2448,7 @@ public class DataStreamIT extends ESIntegTestCase {
                         .mappings(mappings == null ? null : CompressedXContent.fromJSON(mappings))
                         .aliases(aliases)
                         .lifecycle(lifecycle)
-                        .dataStreamOptions(new DataStreamOptions(new DataStreamFailureStore(withFailureStore)))
+                        .dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(withFailureStore))
                 )
                 .metadata(metadata)
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/FailureStoreMetricsWithIncrementalBulkIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/FailureStoreMetricsWithIncrementalBulkIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -165,8 +166,8 @@ public class FailureStoreMetricsWithIncrementalBulkIT extends ESIntegTestCase {
         request.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(DATA_STREAM_NAME + "*"))
-                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false, true))
-                .template(new Template(null, new CompressedXContent("""
+                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+                .template(Template.builder().mappings(new CompressedXContent("""
                     {
                       "dynamic": false,
                       "properties": {
@@ -177,7 +178,7 @@ public class FailureStoreMetricsWithIncrementalBulkIT extends ESIntegTestCase {
                             "type": "long"
                         }
                       }
-                    }"""), null))
+                    }""")).dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
                 .build()
         );
         assertAcked(safeGet(client().execute(TransportPutComposableIndexTemplateAction.TYPE, request)));

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/IngestFailureStoreMetricsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/IngestFailureStoreMetricsIT.java
@@ -23,8 +23,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
-import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
-import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -297,7 +296,7 @@ public class IngestFailureStoreMetricsIT extends ESIntegTestCase {
                             "type": "long"
                         }
                       }
-                    }""")).dataStreamOptions(new DataStreamOptions(new DataStreamFailureStore(failureStore))))
+                    }""")).dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(failureStore)))
                 .build()
         );
         client().execute(TransportPutComposableIndexTemplateAction.TYPE, request).actionGet();

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -39,9 +39,8 @@ import org.elasticsearch.cluster.coordination.StableMasterHealthIndicatorService
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAction;
-import org.elasticsearch.cluster.metadata.DataStreamFailureStore;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
-import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -1228,7 +1227,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
                         .settings(settings)
                         .mappings(mappings == null ? null : CompressedXContent.fromJSON(mappings))
                         .lifecycle(lifecycle)
-                        .dataStreamOptions(new DataStreamOptions(new DataStreamFailureStore(withFailureStore)))
+                        .dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(withFailureStore))
                 )
                 .metadata(metadata)
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/PutDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/PutDataStreamOptionsAction.java
@@ -99,7 +99,7 @@ public class PutDataStreamOptionsAction {
         public Request(TimeValue masterNodeTimeout, TimeValue ackTimeout, String[] names, @Nullable DataStreamFailureStore failureStore) {
             super(masterNodeTimeout, ackTimeout);
             this.names = names;
-            this.options = new DataStreamOptions(DataStreamFailureStore.resolveExplicitNullValues(failureStore));
+            this.options = new DataStreamOptions(failureStore);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
+import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -115,7 +116,8 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         builder.startObject();
         if (this.resolvedTemplate != null) {
             builder.field(TEMPLATE.getPreferredName());
-            this.resolvedTemplate.toXContent(builder, params, rolloverConfiguration);
+            var skipNullsParams = new DelegatingMapParams(Map.of(DataStreamOptions.Template.SKIP_EXPLICIT_NULLS, "true"), params);
+            this.resolvedTemplate.toXContent(builder, skipNullsParams, rolloverConfiguration);
         }
         if (this.overlappingTemplates != null) {
             builder.startArray(OVERLAPPING.getPreferredName());

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -350,7 +350,7 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
         if (template.getDataStreamTemplate() != null && lifecycle == null && isDslOnlyMode) {
             lifecycle = DataStreamLifecycle.DEFAULT;
         }
-        DataStreamOptions dataStreamOptions = resolveDataStreamOptions(simulatedState.metadata(), matchingTemplate);
+        DataStreamOptions.Template dataStreamOptions = resolveDataStreamOptions(simulatedState.metadata(), matchingTemplate);
         return new Template(settings, mergedMapping, aliasesByName, lifecycle, dataStreamOptions);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -656,7 +656,11 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
             ComposableIndexTemplate composableIndexTemplate = metadata.templatesV2().get(template);
             if (composableIndexTemplate.getDataStreamTemplate() != null) {
                 // Check if the data stream has the failure store enabled
-                var options = MetadataIndexTemplateService.resolveDataStreamOptions(composableIndexTemplate, metadata.componentTemplates());
+                var optionsTemplate = MetadataIndexTemplateService.resolveDataStreamOptions(
+                    composableIndexTemplate,
+                    metadata.componentTemplates()
+                );
+                var options = optionsTemplate == null ? null : optionsTemplate.toDataStreamOptions();
                 return options != null && options.isFailureStoreEnabled();
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableOptions.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableOptions.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * This represents all the data stream options configuration that can be explicitly nullified and merged during template composition.
+ */
+public abstract class ComposableOptions implements Writeable, ToXContent {
+
+    public static final String SKIP_EXPLICIT_NULLS = "skip_explicit_nulls";
+
+    private final Map<String, Object> optionsMap;
+
+    public ComposableOptions(Map<String, Object> optionsMap) {
+        this.optionsMap = optionsMap;
+    }
+
+    @Nullable
+    public Boolean getOptionAsBoolean(String field) {
+        Object value = getOptionsMap().get(field);
+        if (value == null) {
+            return null;
+        }
+        return Booleans.parseBoolean(value.toString());
+    }
+
+    /**
+     * Gets the value of the field or null. Null here can mean either that the field is assigned the null value or that it's missing.
+     */
+    @Nullable
+    public Object get(String field) {
+        return this.getOptionsMap().get(field);
+    }
+
+    /**
+     * @return true if the field is defined even if its value is null.
+     */
+    public boolean isDefined(String field) {
+        return getOptionsMap().containsKey(field);
+    }
+
+    /**
+     * @return true if these composable options have been explicitly nullified.
+     */
+    public boolean isNullified() {
+        return getOptionsMap() == null;
+    }
+
+    /**
+     * @return An immutable internal map that holds the options
+     */
+    Map<String, Object> getOptionsMap() {
+        return optionsMap;
+    };
+
+    /**
+     * Converts the template to XContent, when the parameter {@link #SKIP_EXPLICIT_NULLS} is set to true, it will not display any explicit
+     * nulls
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        boolean skipExplicitNulls = params.paramAsBoolean(SKIP_EXPLICIT_NULLS, false);
+        for (String field : getOptionsMap().keySet()) {
+            if (getOptionsMap().containsKey(field)) {
+                Object value = getOptionsMap().get(field);
+                if (value == null && skipExplicitNulls == false) {
+                    builder.nullField(field);
+                } else {
+                    builder.field(field, value);
+                }
+            }
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Recursively applies a set of composable options on top of the current one.
+     * @param newOptions the new values to be applied, null means that the new value set is explicitly nullified.
+     * @param factory a constructor of the concrete class found in this level
+     * @return new composable options that have applied the new values on top of the existing ones.
+     */
+    public <T extends ComposableOptions> T merge(T newOptions, Function<Map<String, Object>, T> factory) {
+        if (newOptions == null || newOptions.isNullified()) {
+            return null;
+        }
+        if (this.isNullified()) {
+            return newOptions;
+        }
+        ImmutableOpenMap.Builder<String, Object> builder = ImmutableOpenMap.builder(this.getOptionsMap());
+        for (Map.Entry<String, Object> entry : newOptions.getOptionsMap().entrySet()) {
+            if (this.getOptionsMap().get(entry.getKey()) instanceof ComposableOptions oldValue
+                && entry.getValue() instanceof ComposableOptions newValue) {
+                builder.put(entry.getKey(), oldValue.merge(newValue, oldValue::create));
+            } else {
+                builder.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return factory.apply(builder.build());
+    }
+
+    /**
+     * Writes a single optional and explicitly nullable value. This method is in direct relation with the
+     * {@link #readOptionalExplicitlyNullable(StreamInput, Map, String, Reader)} which reads the respective value.
+     * @throws IOException
+     */
+    static <T> void writeOptionalExplicitlyNullable(StreamOutput out, boolean isDefined, T value, Writeable.Writer<T> writer)
+        throws IOException {
+        boolean isExplicitNull = isDefined && value == null;
+        out.writeBoolean(isDefined);
+        if (isDefined) {
+            out.writeBoolean(isExplicitNull);
+            if (isExplicitNull == false) {
+                writer.write(out, value);
+            }
+        }
+    }
+
+    static <T> void readOptionalExplicitlyNullable(StreamInput in, Map<String, Object> template, String field, Reader<T> reader)
+        throws IOException {
+        boolean isDefined = in.readBoolean();
+        if (isDefined == false) {
+            return;
+        }
+        boolean isExplicitNull = in.readBoolean();
+        if (isExplicitNull) {
+            template.put(field, null);
+            return;
+        }
+        T value = reader.read(in);
+        template.put(field, value);
+    }
+
+    /**
+     * The factory method of the subclasses
+     */
+    abstract ComposableOptions create(Map<String, Object> optionsMap);
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamOptions.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamOptions.java
@@ -12,33 +12,35 @@ package org.elasticsearch.cluster.metadata;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Holds data stream dedicated configuration options such as failure store, (in the future lifecycle). Currently, it
  * supports the following configurations:
  * - failure store
  */
-public class DataStreamOptions implements SimpleDiffable<DataStreamOptions>, ToXContentObject {
+public record DataStreamOptions(@Nullable DataStreamFailureStore failureStore)
+    implements
+        SimpleDiffable<DataStreamOptions>,
+        ToXContentObject {
 
-    public static final ParseField FAILURE_STORE_FIELD = new ParseField("failure_store");
-    public static final DataStreamOptions FAILURE_STORE_ENABLED = new DataStreamOptions(new DataStreamFailureStore(NullableFlag.TRUE));
-    public static final DataStreamOptions FAILURE_STORE_DISABLED = new DataStreamOptions(new DataStreamFailureStore(NullableFlag.FALSE));
+    public static final String FAILURE_STORE = "failure_store";
+    public static final ParseField FAILURE_STORE_FIELD = new ParseField(FAILURE_STORE);
+    public static final DataStreamOptions FAILURE_STORE_ENABLED = new DataStreamOptions(new DataStreamFailureStore(true));
+    public static final DataStreamOptions FAILURE_STORE_DISABLED = new DataStreamOptions(new DataStreamFailureStore(false));
     public static final DataStreamOptions EMPTY = new DataStreamOptions();
 
     public static final ConstructingObjectParser<DataStreamOptions, Void> PARSER = new ConstructingObjectParser<>(
@@ -46,18 +48,12 @@ public class DataStreamOptions implements SimpleDiffable<DataStreamOptions>, ToX
         false,
         (args, unused) -> new DataStreamOptions((DataStreamFailureStore) args[0])
     );
-    @Nullable
-    private final DataStreamFailureStore failureStore;
-
-    public DataStreamOptions(@Nullable DataStreamFailureStore failureStore) {
-        this.failureStore = failureStore;
-    }
 
     static {
         PARSER.declareObjectOrNull(
             ConstructingObjectParser.optionalConstructorArg(),
             (p, c) -> DataStreamFailureStore.fromXContent(p),
-            DataStreamFailureStore.NULL,
+            null,
             FAILURE_STORE_FIELD
         );
     }
@@ -75,7 +71,7 @@ public class DataStreamOptions implements SimpleDiffable<DataStreamOptions>, ToX
     }
 
     public boolean isEmpty() {
-        return this.equals(EMPTY);
+        return failureStore == null;
     }
 
     /**
@@ -84,7 +80,7 @@ public class DataStreamOptions implements SimpleDiffable<DataStreamOptions>, ToX
      * @return true, if the user has explicitly enabled the failure store.
      */
     public boolean isFailureStoreEnabled() {
-        return failureStore != null && NullableFlag.TRUE.equals(failureStore.enabled());
+        return failureStore != null && Boolean.TRUE.equals(failureStore.enabled());
     }
 
     @Override
@@ -112,103 +108,64 @@ public class DataStreamOptions implements SimpleDiffable<DataStreamOptions>, ToX
     }
 
     /**
-     * Creates a class that composes the different fields of the data stream options and normalises explicitly nullified fields.
+     * This class is only used in template configuration. It allows us to represent explicit null values and denotes that the fields
+     * of the failure can be merged.
      */
-    public static Composer composer(DataStreamOptions options) {
-        return new Composer(options);
-    }
+    public static class Template extends ComposableOptions {
+        public static final Template EMPTY = new Template(Map.of());
 
-    @Nullable
-    public DataStreamFailureStore failureStore() {
-        return failureStore;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (DataStreamOptions) obj;
-        return Objects.equals(this.failureStore, that.failureStore);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(failureStore);
-    }
-
-    /**
-     * Composes different data stream options to a normalised final value.
-     */
-    public static class Composer {
-        private DataStreamFailureStore failureStore;
-
-        private Composer(DataStreamOptions options) {
-            failureStore = DataStreamFailureStore.resolveExplicitNullValues(options.failureStore);
+        public Template(Map<String, Object> template) {
+            super(template);
         }
 
-        public void apply(DataStreamOptions dataStreamOptions) {
-            if (dataStreamOptions.failureStore != null) {
-                this.failureStore = dataStreamOptions.failureStore.isNullified() ? null : dataStreamOptions.failureStore;
-            }
-        }
-
-        public DataStreamOptions compose() {
-            return new DataStreamOptions(failureStore);
-        }
-    }
-
-    /**
-     * This flag is used to capture the explicit null value of a boolean value in data stream options. The
-     * explicit null values are used to reset that flag during template composition.
-     */
-    public enum NullableFlag implements Writeable, ToXContent {
-        TRUE(0),
-        FALSE(1),
-        NULL_VALUE(2);
-
-        private final byte id;
-        private static final Map<Byte, NullableFlag> REGISTRY;
+        public static final ObjectParser<ImmutableOpenMap.Builder<String, Object>, Void> PARSER = new ObjectParser<>("data_stream_options");
 
         static {
-            REGISTRY = Arrays.stream(values()).collect(Collectors.toMap(flag -> flag.id, flag -> flag));
-        }
-
-        NullableFlag(int id) {
-            this.id = (byte) id;
-        }
-
-        public static NullableFlag fromBoolean(@Nullable Boolean flag) {
-            if (flag == null) {
-                return null;
-            }
-            return flag ? TRUE : FALSE;
-        }
-
-        public static NullableFlag read(StreamInput in) throws IOException {
-            byte id = in.readByte();
-            NullableFlag flag = REGISTRY.get(id);
-            if (flag == null) {
-                throw new IllegalArgumentException("Unknown flag [" + id + "]");
-            }
-            return flag;
+            PARSER.declareObjectOrNull(
+                (map, v) -> map.put(FAILURE_STORE, v),
+                (p, s) -> DataStreamFailureStore.Template.fromXContent(p),
+                null,
+                FAILURE_STORE_FIELD
+            );
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeByte(id);
+            ComposableOptions.writeOptionalExplicitlyNullable(
+                out,
+                isDefined(FAILURE_STORE),
+                (DataStreamFailureStore.Template) get(FAILURE_STORE),
+                (o, value) -> value.writeTo(o)
+            );
+        }
+
+        public static Template read(StreamInput in) throws IOException {
+            Map<String, Object> template = new HashMap<>();
+            ComposableOptions.readOptionalExplicitlyNullable(in, template, FAILURE_STORE, DataStreamFailureStore.Template::read);
+            return new Template(template);
+        }
+
+        public static Template fromXContent(XContentParser parser) throws IOException {
+            ImmutableOpenMap.Builder<String, Object> map = ImmutableOpenMap.builder();
+            PARSER.parse(parser, map, null);
+            return new Template(map.build());
+        }
+
+        @Nullable
+        public DataStreamOptions toDataStreamOptions() {
+            if (isNullified()) {
+                return null;
+            }
+            DataStreamFailureStore.Template failureStoreTemplate = (DataStreamFailureStore.Template) get(FAILURE_STORE);
+            if (failureStoreTemplate == null) {
+                return DataStreamOptions.EMPTY;
+            }
+            return new DataStreamOptions(failureStoreTemplate.toFailureStore());
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return switch (this) {
-                case TRUE -> builder.value(true);
-                case FALSE -> builder.value(false);
-                case NULL_VALUE -> builder.nullValue();
-            };
-        }
-
-        public static boolean isDefined(@Nullable NullableFlag flag) {
-            return flag != null && flag != NullableFlag.NULL_VALUE;
+        public ComposableOptions create(Map<String, Object> optionsMap) {
+            return new Template(optionsMap);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -261,9 +261,12 @@ public class MetadataCreateDataStreamService {
         // This is not a problem as both have different prefixes (`.ds-` vs `.fs-`) and both will be using the same `generation` field
         // when rolling over in the future.
         final long initialGeneration = 1;
-        final DataStreamOptions dataStreamOptions = isSystem
+        DataStreamOptions.Template dataStreamOptionsTemplate = isSystem
             ? MetadataIndexTemplateService.resolveDataStreamOptions(template, systemDataStreamDescriptor.getComponentTemplates())
             : MetadataIndexTemplateService.resolveDataStreamOptions(template, metadata.componentTemplates());
+        final DataStreamOptions dataStreamOptions = dataStreamOptionsTemplate == null
+            ? null
+            : dataStreamOptionsTemplate.toDataStreamOptions();
         var isFailureStoreEnabled = dataStreamOptions != null && dataStreamOptions.isFailureStoreEnabled();
 
         // If we need to create a failure store, do so first. Do not reroute during the creation since we will do

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateResponseTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComponentTemplateTests;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.DataStreamOptions;
-import org.elasticsearch.cluster.metadata.DataStreamOptionsTests;
+import org.elasticsearch.cluster.metadata.DataStreamOptionsTemplateTests;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -67,7 +67,7 @@ public class GetComponentTemplateResponseTests extends AbstractWireSerializingTe
         CompressedXContent mappings = null;
         Map<String, AliasMetadata> aliases = null;
         DataStreamLifecycle lifecycle = new DataStreamLifecycle();
-        DataStreamOptions dataStreamOptions = null;
+        DataStreamOptions.Template dataStreamOptions = null;
         if (randomBoolean()) {
             settings = randomSettings();
         }
@@ -78,7 +78,7 @@ public class GetComponentTemplateResponseTests extends AbstractWireSerializingTe
             aliases = randomAliases();
         }
         if (randomBoolean()) {
-            dataStreamOptions = DataStreamOptionsTests.randomDataStreamOptions();
+            dataStreamOptions = DataStreamOptionsTemplateTests.randomDataStreamOptions();
         }
 
         var template = new ComponentTemplate(

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
@@ -147,13 +147,13 @@ public class BulkOperationTests extends ESTestCase {
                         ComposableIndexTemplate.builder()
                             .indexPatterns(List.of(dataStreamName))
                             .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
-                            .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_DISABLED))
+                            .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(false)))
                             .build(),
                         "ds-template-with-failure-store",
                         ComposableIndexTemplate.builder()
                             .indexPatterns(List.of(fsDataStreamName, fsRolloverDataStreamName))
                             .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
-                            .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED))
+                            .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
                             .build()
                     )
                 )

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
-import org.elasticsearch.cluster.metadata.DataStreamOptions;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -323,7 +323,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
                     WITH_FAILURE_STORE_ENABLED,
                     ComposableIndexTemplate.builder()
                         .indexPatterns(List.of(WITH_FAILURE_STORE_ENABLED + "*"))
-                        .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED))
+                        .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
                         .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                         .build()
                 )

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
-import org.elasticsearch.cluster.metadata.DataStreamOptions;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexAbstraction.ConcreteIndex;
@@ -466,13 +465,13 @@ public class TransportBulkActionTests extends ESTestCase {
                     dsTemplateWithFailureStore,
                     ComposableIndexTemplate.builder()
                         .indexPatterns(List.of(dsTemplateWithFailureStore + "-*"))
-                        .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED))
+                        .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
                         .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                         .build(),
                     dsTemplateWithoutFailureStore,
                     ComposableIndexTemplate.builder()
                         .indexPatterns(List.of(dsTemplateWithoutFailureStore + "-*"))
-                        .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_DISABLED))
+                        .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(false)))
                         .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
                         .build(),
                     indexTemplate,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
@@ -93,7 +93,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
             templateBuilder.lifecycle(DataStreamLifecycleTests.randomLifecycle());
         }
         if (randomBoolean() && supportsDataStreams) {
-            templateBuilder.dataStreamOptions(randomDataStreamOptions());
+            templateBuilder.dataStreamOptions(DataStreamOptionsTemplateTests.randomDataStreamOptions());
         }
         Template template = templateBuilder.build();
 
@@ -102,12 +102,6 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
             meta = randomMeta();
         }
         return new ComponentTemplate(template, randomBoolean() ? null : randomNonNegativeLong(), meta, deprecated);
-    }
-
-    private static DataStreamOptions randomDataStreamOptions() {
-        return rarely() ? Template.NO_DATA_STREAM_OPTIONS
-            : randomBoolean() ? DataStreamOptionsTests.randomDataStreamOptions()
-            : new DataStreamOptions(DataStreamFailureStore.NULL);
     }
 
     public static Map<String, AliasMetadata> randomAliases() {
@@ -188,7 +182,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
                     case 4 -> new ComponentTemplate(
                         Template.builder(ot)
                             .dataStreamOptions(
-                                randomValueOtherThan(ot.dataStreamOptions(), ComponentTemplateTests::randomDataStreamOptions)
+                                randomValueOtherThan(ot.dataStreamOptions(), DataStreamOptionsTemplateTests::randomDataStreamOptions)
                             )
                             .build(),
                         orig.version(),
@@ -270,7 +264,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
         Settings settings = null;
         CompressedXContent mappings = null;
         Map<String, AliasMetadata> aliases = null;
-        DataStreamOptions dataStreamOptions = null;
+        DataStreamOptions.Template dataStreamOptions = null;
         if (randomBoolean()) {
             settings = randomSettings();
         }
@@ -281,7 +275,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
             aliases = randomAliases();
         }
         if (randomBoolean()) {
-            dataStreamOptions = randomDataStreamOptions();
+            dataStreamOptions = DataStreamOptionsTemplateTests.randomDataStreamOptions();
         }
         DataStreamLifecycle lifecycle = new DataStreamLifecycle();
         ComponentTemplate template = new ComponentTemplate(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -219,7 +219,7 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
         Settings settings = null;
         CompressedXContent mappings = null;
         Map<String, AliasMetadata> aliases = null;
-        DataStreamOptions dataStreamOptions = null;
+        DataStreamOptions.Template dataStreamOptions = null;
         ComposableIndexTemplate.DataStreamTemplate dataStreamTemplate = randomDataStreamTemplate();
         if (randomBoolean()) {
             settings = randomSettings();
@@ -231,7 +231,7 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
             aliases = randomAliases();
         }
         if (randomBoolean()) {
-            dataStreamOptions = DataStreamOptionsTests.randomDataStreamOptions();
+            dataStreamOptions = DataStreamOptionsTemplateTests.randomDataStreamOptions();
         }
         // We use the empty lifecycle so the global retention can be in effect
         DataStreamLifecycle lifecycle = new DataStreamLifecycle();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreTests.java
@@ -16,8 +16,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class DataStreamFailureStoreTests extends AbstractXContentSerializingTestCase<DataStreamFailureStore> {
 
@@ -33,8 +31,8 @@ public class DataStreamFailureStoreTests extends AbstractXContentSerializingTest
 
     @Override
     protected DataStreamFailureStore mutateInstance(DataStreamFailureStore instance) throws IOException {
-        // We know the enabled is not null because in this test we do not include the DataStreamFailureStore.NULL
-        return new DataStreamFailureStore(instance.enabled() == DataStreamOptions.NullableFlag.FALSE);
+        // We know the enabled is not null because we can't support it until we get more parameters
+        return new DataStreamFailureStore(instance.enabled() == false);
     }
 
     @Override
@@ -47,20 +45,7 @@ public class DataStreamFailureStoreTests extends AbstractXContentSerializingTest
     }
 
     public void testInvalidEmptyConfiguration() {
-        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> new DataStreamFailureStore((Boolean) null));
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> new DataStreamFailureStore(null));
         assertThat(exception.getMessage(), containsString("at least one non-null configuration value"));
-
-        exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> new DataStreamFailureStore(DataStreamOptions.NullableFlag.NULL_VALUE)
-        );
-        assertThat(exception.getMessage(), containsString("at least one non-null configuration value"));
-    }
-
-    public void testExplicitNullValueResolution() {
-        assertThat(DataStreamFailureStore.resolveExplicitNullValues(null), nullValue());
-        assertThat(DataStreamFailureStore.resolveExplicitNullValues(DataStreamFailureStore.NULL), nullValue());
-        DataStreamFailureStore nonNull = randomFailureStore();
-        assertThat(DataStreamFailureStore.resolveExplicitNullValues(nonNull), equalTo(nonNull));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamOptionsTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamOptionsTemplateTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class DataStreamOptionsTemplateTests extends AbstractXContentSerializingTestCase<DataStreamOptions.Template> {
+
+    @Override
+    protected Writeable.Reader<DataStreamOptions.Template> instanceReader() {
+        return DataStreamOptions.Template::read;
+    }
+
+    @Override
+    protected DataStreamOptions.Template createTestInstance() {
+        return randomDataStreamOptions();
+    }
+
+    public static DataStreamOptions.Template randomDataStreamOptions() {
+        return switch (randomIntBetween(0, 4)) {
+            case 0 -> DataStreamOptions.Template.EMPTY;
+            case 1 -> new DataStreamOptions.Template(
+                Map.of("failure_store", new DataStreamFailureStore.Template(Map.of("enabled", false)))
+            );
+            case 2 -> new DataStreamOptions.Template(Map.of("failure_store", new DataStreamFailureStore.Template(Map.of("enabled", true))));
+            case 3 -> new DataStreamOptions.Template(null);
+            case 4 -> new DataStreamOptions.Template(Map.of("failure_store", new DataStreamFailureStore.Template(null)));
+            default -> throw new IllegalArgumentException("Illegal randomisation branch");
+        };
+    }
+
+    @Override
+    protected DataStreamOptions.Template mutateInstance(DataStreamOptions.Template instance) throws IOException {
+        return randomValueOtherThan(instance, DataStreamOptionsTemplateTests::randomDataStreamOptions);
+    }
+
+    @Override
+    protected DataStreamOptions.Template doParseInstance(XContentParser parser) throws IOException {
+        return DataStreamOptions.Template.fromXContent(parser);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -137,13 +137,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             case 10 -> failureIndices = randomValueOtherThan(failureIndices, DataStreamTestHelper::randomIndexInstances);
             case 11 -> dataStreamOptions = dataStreamOptions.isEmpty() ? new DataStreamOptions(new DataStreamFailureStore(randomBoolean()))
                 : randomBoolean() ? (randomBoolean() ? null : DataStreamOptions.EMPTY)
-                : new DataStreamOptions(
-                    new DataStreamFailureStore(
-                        dataStreamOptions.failureStore().enabled() == DataStreamOptions.NullableFlag.FALSE
-                            ? DataStreamOptions.NullableFlag.TRUE
-                            : DataStreamOptions.NullableFlag.FALSE
-                    )
-                );
+                : new DataStreamOptions(new DataStreamFailureStore(dataStreamOptions.failureStore().enabled() == false));
             case 12 -> {
                 rolloverOnWrite = rolloverOnWrite == false;
                 isReplicated = rolloverOnWrite == false && isReplicated;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -268,7 +268,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         final String dataStreamName = "my-data-stream";
         ComposableIndexTemplate template = ComposableIndexTemplate.builder()
             .indexPatterns(List.of(dataStreamName + "*"))
-            .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED))
+            .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
             .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
             .build();
         ClusterState cs = ClusterState.builder(new ClusterName("_name"))
@@ -310,7 +310,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         final String dataStreamName = "my-data-stream";
         ComposableIndexTemplate template = ComposableIndexTemplate.builder()
             .indexPatterns(List.of(dataStreamName + "*"))
-            .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED))
+            .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
             .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
             .build();
         ClusterState cs = ClusterState.builder(new ClusterName("_name"))
@@ -349,7 +349,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
         final String dataStreamName = "my-data-stream";
         ComposableIndexTemplate template = ComposableIndexTemplate.builder()
             .indexPatterns(List.of(dataStreamName + "*"))
-            .template(Template.builder().dataStreamOptions(DataStreamOptions.FAILURE_STORE_ENABLED))
+            .template(Template.builder().dataStreamOptions(DataStreamTestHelper.createDataStreamOptionsTemplate(true)))
             .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
             .build();
         ClusterState cs = ClusterState.builder(new ClusterName("_name"))

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -466,7 +466,7 @@ public final class DataStreamTestHelper {
                 .template(
                     Template.builder()
                         .dataStreamOptions(
-                            DataStream.isFailureStoreFeatureFlagEnabled() && storeFailures ? DataStreamOptions.FAILURE_STORE_ENABLED : null
+                            DataStream.isFailureStoreFeatureFlagEnabled() && storeFailures ? createDataStreamOptionsTemplate(true) : null
                         )
                 )
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
@@ -738,6 +738,15 @@ public final class DataStreamTestHelper {
             return ((CheckedFunction<IndexService, ?, ?>) invocationOnMock.getArguments()[1]).apply(indexService);
         });
         return indicesService;
+    }
+
+    public static DataStreamOptions.Template createDataStreamOptionsTemplate(Boolean failureStore) {
+        if (failureStore == null) {
+            return DataStreamOptions.Template.EMPTY;
+        }
+        return new DataStreamOptions.Template(
+            Map.of("failure_store", new DataStreamFailureStore.Template(Map.of("enabled", failureStore)))
+        );
     }
 
 }


### PR DESCRIPTION
In this PoC, we are trying to introduce a new framework for configuring data stream options, see the `ComposableOptions` in [d8fdc236467966424ab36e4dbd0eded46acc7c58](https://github.com/gmarouli/elasticsearch/pull/9/commits/d8fdc236467966424ab36e4dbd0eded46acc7c58). This is an alternative of https://github.com/elastic/elasticsearch/pull/113863.

Initially we wanted to use the Settings, but this cannot support lists of anything more complex than a String and we need more than that to capture downsampling. Furthermore, Settings work the best with the values as leaves, but this doesn't fit well with both representations:
```
{ 
  "failure_store": null
}

{ 
  "failure_store": {
    "enabled": true
  }
}
```

This framework tries to facilitate:

- Explicitly nullified values
- Explicit merging on the requested levels
- 